### PR TITLE
Task00 Василий Ионин CSC

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,19 +67,34 @@ int main()
         // Затем откройте документацию по clGetPlatformInfo и в секции Errors найдите ошибку, с которой столкнулись
         // в документации подробно объясняется, какой ситуации соответствует данная ошибка, и это позволит, проверив код, понять, чем же вызвана данная ошибка (некорректным аргументом param_name)
         // Обратите внимание, что в этом же libs/clew/CL/cl.h файле указаны всевоможные defines, такие как CL_DEVICE_TYPE_GPU и т.п.
+        /*
+         * Вызов `OCL_SAFE_CALL(clGetPlatformInfo(platform, 239, 0, nullptr, &platformNameSize));` влечет ошибку -30 (CL_INVALID_VALUE).
+         * В документации написано "...clGetPlatformInfo returns CL_INVALID_VALUE if param_name is not one of the supported values
+         * or if size in bytes specified by param_value_size is less than size of return type and param_value is not a NULL value."
+         */
 
         // TODO 1.2
         // Аналогично тому, как был запрошен список идентификаторов всех платформ - так и с названием платформы, теперь, когда известна длина названия - его можно запросить:
         std::vector<unsigned char> platformName(platformNameSize, 0);
-        // clGetPlatformInfo(...);
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_NAME, platformNameSize, platformName.data(), nullptr));
         std::cout << "    Platform name: " << platformName.data() << std::endl;
 
         // TODO 1.3
         // Запросите и напечатайте так же в консоль вендора данной платформы
+        size_t platformVendorSize = 0;
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, 0, nullptr, &platformVendorSize));
+        std::vector<unsigned char> platformVendor(platformVendorSize, 0);
+        OCL_SAFE_CALL(clGetPlatformInfo(platform, CL_PLATFORM_VENDOR, platformVendorSize, platformVendor.data(), nullptr));
+        std::cout << "    Platform vendor: " << platformVendor.data() << std::endl;
 
         // TODO 2.1
         // Запросите число доступных устройств данной платформы (аналогично тому, как это было сделано для запроса числа доступных платформ - см. секцию "OpenCL Runtime" -> "Query Devices")
         cl_uint devicesCount = 0;
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &devicesCount));
+        std::cout << "    Number of devices: " << devicesCount << std::endl;
+
+        std::vector<cl_device_id> devices(devicesCount);
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, devicesCount, devices.data(), nullptr));
 
         for (int deviceIndex = 0; deviceIndex < devicesCount; ++deviceIndex) {
             // TODO 2.2
@@ -88,6 +103,42 @@ int main()
             // - Тип устройства (видеокарта/процессор/что-то странное)
             // - Размер памяти устройства в мегабайтах
             // - Еще пару или более свойств устройства, которые вам покажутся наиболее интересными
+            std::cout << "    Device #" << (deviceIndex + 1) << "/" << devicesCount << std::endl;
+            cl_device_id device = devices[deviceIndex];
+
+            size_t deviceNameSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_NAME, 0, nullptr, &deviceNameSize));
+            std::vector<unsigned char> deviceName(deviceNameSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_NAME, deviceNameSize, deviceName.data(), nullptr));
+            std::cout << "        Name: " << deviceName.data() << std::endl;
+
+            cl_device_type deviceType;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_TYPE, sizeof(deviceType), &deviceType, nullptr));
+            switch (deviceType) {
+                case CL_DEVICE_TYPE_GPU:
+                    std::cout << "        Type: GPU" << std::endl;
+                    break;
+                case CL_DEVICE_TYPE_CPU:
+                    std::cout << "        Type: CPU" << std::endl;
+                    break;
+                default:
+                    std::cout << "        Type: ???" << std::endl;
+                    break;
+            }
+
+            cl_ulong deviceGlobalMemSize;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_SIZE, sizeof(cl_ulong), &deviceGlobalMemSize, nullptr));
+            std::cout << "        Global memory size: " << deviceGlobalMemSize / (1 << 20) << "M" << std::endl;
+
+            cl_ulong deviceMemCacheSize;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_GLOBAL_MEM_CACHE_SIZE, sizeof(cl_ulong), &deviceMemCacheSize, nullptr));
+            std::cout << "        Global memory cache size: " << deviceMemCacheSize / (1 << 10) << "K" << std::endl;
+
+            size_t deviceExtensionsSize = 0;
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, 0, nullptr, &deviceExtensionsSize));
+            std::vector<unsigned char> deviceExtensions(deviceExtensionsSize, 0);
+            OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_EXTENSIONS, deviceExtensionsSize, deviceExtensions.data(), nullptr));
+            std::cout << "        Extensions: " << deviceExtensions.data() << std::endl;
         }
     }
 


### PR DESCRIPTION
<details><summary>Локальный вывод</summary><p>
<pre>
$ ./enumDevices
Number of OpenCL platforms: 2
Platform #1/2
    Platform name: Intel(R) OpenCL HD Graphics
    Platform vendor: Intel(R) Corporation
    Number of devices: 1
    Device #1/1
        Name: Intel(R) UHD Graphics 620 [0x5917]
        Type: GPU
        Global memory size: 12709M
        Global memory cache size: 512K
        Extensions: cl_khr_byte_addressable_store cl_khr_fp16 cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_icd cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_intel_command_queue_families cl_intel_subgroups cl_intel_required_subgroup_size cl_intel_subgroups_short cl_khr_spir cl_intel_accelerator cl_intel_driver_diagnostics cl_khr_priority_hints cl_khr_throttle_hints cl_khr_create_command_queue cl_intel_subgroups_char cl_intel_subgroups_long cl_khr_il_program cl_intel_mem_force_host_memory cl_khr_subgroup_extended_types cl_khr_subgroup_non_uniform_vote cl_khr_subgroup_ballot cl_khr_subgroup_non_uniform_arithmetic cl_khr_subgroup_shuffle cl_khr_subgroup_shuffle_relative cl_khr_subgroup_clustered_reduce cl_intel_device_attribute_query cl_khr_fp64 cl_khr_subgroups cl_intel_spirv_device_side_avc_motion_estimation cl_intel_spirv_media_block_io cl_intel_spirv_subgroups cl_khr_spirv_no_integer_wrap_decoration cl_intel_unified_shared_memory_preview cl_khr_mipmap_image cl_khr_mipmap_image_writes cl_intel_planar_yuv cl_intel_packed_yuv cl_intel_motion_estimation cl_intel_device_side_avc_motion_estimation cl_intel_advanced_motion_estimation cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_image2d_from_buffer cl_khr_depth_images cl_khr_3d_image_writes cl_intel_media_block_io cl_intel_va_api_media_sharing cl_intel_sharing_format_query 
Platform #2/2
    Platform name: Intel(R) CPU Runtime for OpenCL(TM) Applications
    Platform vendor: Intel(R) Corporation
    Number of devices: 1
    Device #1/1
        Name: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
        Type: CPU
        Global memory size: 15887M
        Global memory cache size: 256K
        Extensions: cl_khr_icd cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_depth_images cl_khr_3d_image_writes cl_intel_exec_by_local_thread cl_khr_spir cl_khr_fp64 cl_khr_image2d_from_buffer cl_intel_vec_len_hint
</pre>

</p></details>
<details><summary>Вывод Travis CI</summary><p>
<pre>
$ ./enumDevices
Number of OpenCL platforms: 1
Platform #1/1
    Platform name: Intel(R) OpenCL
    Platform vendor: Intel(R) Corporation
    Number of devices: 1
    Device #1/1
        Name:            Intel(R) Xeon(R) CPU
        Type: CPU
        Global memory size: 7958M
        Global memory cache size: 256K
        Extensions: cl_khr_icd cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_byte_addressable_store cl_khr_depth_images cl_khr_3d_image_writes cl_intel_exec_by_local_thread cl_khr_spir cl_khr_fp64 cl_khr_image2d_from_buffer cl_intel_vec_len_hint 
The command "./enumDevices" exited with 0.
</pre>
</p></details>