### PR TITLE
Task01 Kononov Nickolay CSC

### DIFF
--- a/src/cl/aplusb.cl
+++ b/src/cl/aplusb.cl
@@ -11,11 +11,16 @@
 // - На вход дано три массива float чисел; единственное, чем они отличаются от обычных указателей - модификатором __global, т.к. это глобальная память устройства (видеопамять)
 // - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное, чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)
 
-__kernel void aplusb(...)
+__kernel void aplusb(__global float* src1, __global float* src2, __global float* dst, unsigned int n)
 {
     // Узнать, какой workItem выполняется в этом потоке поможет функция get_global_id
     // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
     // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
+    const unsigned int index = get_global_id(0);
+    if (index >= n) {
+        return;
+    }
+    dst[index] = src1[index] + src2[index];
 
     // P.S. В общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
     // и в таком случае, если сделать обращение к массиву просто по индексу=get_global_id(0), будет undefined behaviour (вплоть до повисания ОС)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -33,6 +33,38 @@ void reportError(cl_int err, const std::string &filename, int line)
 
 #define OCL_SAFE_CALL(expr) reportError(expr, __FILE__, __LINE__)
 
+#define OCL_CHECK_STATUS(status) OCL_SAFE_CALL(status)
+
+cl_device_id getDevice()
+{
+    cl_uint platformsCount = 0;
+    OCL_SAFE_CALL(clGetPlatformIDs(0, nullptr, &platformsCount));
+    std::vector<cl_platform_id> platforms(platformsCount);
+    OCL_SAFE_CALL(clGetPlatformIDs(platformsCount, platforms.data(), nullptr));
+
+    std::vector<cl_device_id> all_devices {};
+
+    for (int platformIndex = 0; platformIndex < platformsCount; ++platformIndex) {
+        cl_platform_id platform = platforms[platformIndex];
+        cl_uint devicesCount = 0;
+        OCL_SAFE_CALL(clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, 0, nullptr, &devicesCount));
+        auto old_size = all_devices.size();
+        all_devices.resize(old_size + devicesCount);
+        OCL_SAFE_CALL(
+            clGetDeviceIDs(platform, CL_DEVICE_TYPE_ALL, devicesCount, all_devices.data() + old_size, nullptr));
+    }
+    if (all_devices.size() == 0) {
+        throw std::runtime_error {"Can't find OpenCl devices"};
+    }
+    for (auto &device : all_devices) {
+        cl_device_type deviceType;
+        OCL_SAFE_CALL(clGetDeviceInfo(device, CL_DEVICE_TYPE, sizeof(cl_device_type), &deviceType, nullptr));
+        if (deviceType == CL_DEVICE_TYPE_GPU) {
+            return device;
+        }
+    }
+    return all_devices[0];
+}
 
 int main()
 {
@@ -42,19 +74,25 @@ int main()
 
     // TODO 1 По аналогии с предыдущим заданием узнайте, какие есть устройства, и выберите из них какое-нибудь
     // (если в списке устройств есть хоть одна видеокарта - выберите ее, если нету - выбирайте процессор)
+    cl_device_id device = getDevice();
 
     // TODO 2 Создайте контекст с выбранным устройством
     // См. документацию https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/ -> OpenCL Runtime -> Contexts -> clCreateContext
     // Не забывайте проверять все возвращаемые коды на успешность (обратите внимание, что в данном случае метод возвращает
     // код по переданному аргументом errcode_ret указателю)
     // И хорошо бы сразу добавить в конце clReleaseContext (да, не очень RAII, но это лишь пример)
+    cl_int status;
+    auto context = clCreateContext(NULL, 1, &device, NULL, NULL, &status);
+    OCL_CHECK_STATUS(status);
 
     // TODO 3 Создайте очередь выполняемых команд в рамках выбранного контекста и устройства
     // См. документацию https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/ -> OpenCL Runtime -> Runtime APIs -> Command Queues -> clCreateCommandQueue
     // Убедитесь, что в соответствии с документацией вы создали in-order очередь задач
     // И хорошо бы сразу добавить в конце clReleaseQueue (не забывайте освобождать ресурсы)
+    auto command_queue = clCreateCommandQueue(context, device, 0, &status);
+    OCL_CHECK_STATUS(status);
 
-    unsigned int n = 1000*1000;
+    unsigned int n = 100 * 1000 * 1000;
     // Создаем два массива псевдослучайных данных для сложения и массив для будущего хранения результата
     std::vector<float> as(n, 0);
     std::vector<float> bs(n, 0);
@@ -72,6 +110,19 @@ int main()
     // Данные в as и bs можно прогрузить этим же методом, скопировав данные из host_ptr=as.data() (и не забыв про битовый флаг, на это указывающий)
     // или же через метод Buffer Objects -> clEnqueueWriteBuffer
     // И хорошо бы сразу добавить в конце clReleaseMemObject (аналогично, все дальнейшие ресурсы вроде OpenCL под-программы, кернела и т.п. тоже нужно освобождать)
+    size_t buffersSize = n * sizeof(float);
+
+    cl_mem numbers1 = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, buffersSize, as.data(), &status);
+    OCL_CHECK_STATUS(status);
+    // OCL_CHECK_STATUS(clEnqueueWriteBuffer(command_queue, numbers1, CL_TRUE, 0, buffersSize, as.data(), 0, NULL, NULL));
+
+    cl_mem numbers2 = clCreateBuffer(context, CL_MEM_READ_ONLY | CL_MEM_COPY_HOST_PTR, buffersSize, bs.data(), &status);
+    OCL_CHECK_STATUS(status);
+    // OCL_CHECK_STATUS(clEnqueueWriteBuffer(command_queue, numbers2, CL_TRUE, 0, buffersSize, bs.data(), 0, NULL, NULL));
+
+    cl_mem output = clCreateBuffer(context, CL_MEM_WRITE_ONLY, buffersSize, NULL, &status);
+    OCL_CHECK_STATUS(status);
+
 
     // TODO 6 Выполните TODO 5 (реализуйте кернел в src/cl/aplusb.cl)
     // затем убедитесь, что выходит загрузить его с диска (убедитесь что Working directory выставлена правильно - см. описание задания),
@@ -83,40 +134,51 @@ int main()
         if (kernel_sources.size() == 0) {
             throw std::runtime_error("Empty source file! May be you forgot to configure working directory properly?");
         }
-        // std::cout << kernel_sources << std::endl;
+        std::cout << "\nKernel Sources:\n" << kernel_sources << std::endl;
     }
 
     // TODO 7 Создайте OpenCL-подпрограмму с исходниками кернела
     // см. Runtime APIs -> Program Objects -> clCreateProgramWithSource
     // у string есть метод c_str(), но обратите внимание, что передать вам нужно указатель на указатель
+    const char *program_c_str = kernel_sources.c_str();
+    cl_program program = clCreateProgramWithSource(context, 1, &program_c_str, NULL, &status);
+    OCL_CHECK_STATUS(status);
+
 
     // TODO 8 Теперь скомпилируйте программу и напечатайте в консоль лог компиляции
     // см. clBuildProgram
+    OCL_SAFE_CALL(clBuildProgram(program, 1, &device, NULL, NULL, NULL));
 
     // А также напечатайте лог компиляции (он будет очень полезен, если в кернеле есть синтаксические ошибки - т.е. когда clBuildProgram вернет CL_BUILD_PROGRAM_FAILURE)
     // Обратите внимание, что при компиляции на процессоре через Intel OpenCL драйвер - в логе указывается, какой ширины векторизацию получилось выполнить для кернела
     // см. clGetProgramBuildInfo
-//    size_t log_size = 0;
-//    std::vector<char> log(log_size, 0);
-//    if (log_size > 1) {
-//        std::cout << "Log:" << std::endl;
-//        std::cout << log.data() << std::endl;
-//    }
+    size_t log_size = 0;
+    status = clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, 0, NULL, &log_size);
+    std::vector<char> log(log_size, 0);
+    OCL_SAFE_CALL(clGetProgramBuildInfo(program, device, CL_PROGRAM_BUILD_LOG, log_size, log.data(), NULL));
+    if (log_size > 1) {
+        std::cout << "\nKernel Build Log:\n" << log.data() << std::endl;
+    }
+    OCL_CHECK_STATUS(status);
 
     // TODO 9 Создайте OpenCL-kernel в созданной подпрограмме (в одной подпрограмме может быть несколько кернелов, но в данном случае кернел один)
     // см. подходящую функцию в Runtime APIs -> Program Objects -> Kernel Objects
+    status = 0;
+    cl_kernel kernel = clCreateKernel(program, "aplusb", &status);
+    OCL_SAFE_CALL(status);
 
     // TODO 10 Выставите все аргументы в кернеле через clSetKernelArg (as_gpu, bs_gpu, cs_gpu и число значений, убедитесь, что тип количества элементов такой же в кернеле)
     {
-        // unsigned int i = 0;
-        // clSetKernelArg(kernel, i++, ..., ...);
-        // clSetKernelArg(kernel, i++, ..., ...);
-        // clSetKernelArg(kernel, i++, ..., ...);
-        // clSetKernelArg(kernel, i++, ..., ...);
+        unsigned int i = 0;
+        status = clSetKernelArg(kernel, i++, sizeof(float *), &numbers1);
+        status |= clSetKernelArg(kernel, i++, sizeof(float *), &numbers2);
+        status |= clSetKernelArg(kernel, i++, sizeof(float *), &output);
+        status |= clSetKernelArg(kernel, i++, sizeof(unsigned int), &n);
+        OCL_CHECK_STATUS(status);
     }
 
     // TODO 11 Выше увеличьте n с 1000*1000 до 100*1000*1000 (чтобы дальнейшие замеры были ближе к реальности)
-    
+
     // TODO 12 Запустите выполнения кернела:
     // - С одномерной рабочей группой размера 128
     // - В одномерном рабочем пространстве размера roundedUpN, где roundedUpN - наименьшее число, кратное 128 и при этом не меньшее n
@@ -129,8 +191,9 @@ int main()
         size_t global_work_size = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
         timer t; // Это вспомогательный секундомер, он замеряет время своего создания и позволяет усреднять время нескольких замеров
         for (unsigned int i = 0; i < 20; ++i) {
-            // clEnqueueNDRangeKernel...
-            // clWaitForEvents...
+            cl_event event;
+            OCL_SAFE_CALL(clEnqueueNDRangeKernel(command_queue, kernel, 1, NULL, &global_work_size, &workGroupSize, 0, NULL, &event));
+            OCL_SAFE_CALL(clWaitForEvents(1, &event));
             t.nextLap(); // При вызове nextLap секундомер запоминает текущий замер (текущий круг) и начинает замерять время следующего круга
         }
         // Среднее время круга (вычисления кернела) на самом деле считается не по всем замерам, а лишь с 20%-перцентайля по 80%-перцентайль (как и стандартное отклонение)
@@ -144,7 +207,7 @@ int main()
         // - Флопс - это число операций с плавающей точкой в секунду
         // - В гигафлопсе 10^9 флопсов
         // - Среднее время выполнения кернела равно t.lapAvg() секунд
-        std::cout << "GFlops: " << 0 << std::endl;
+        std::cout << "GFlops: " << n / t.lapAvg() / 1000000000 << std::endl;
 
         // TODO 14 Рассчитайте используемую пропускную способность обращений к видеопамяти (в гигабайтах в секунду)
         // - Всего элементов в массивах по n штук
@@ -152,26 +215,35 @@ int main()
         // - Обращений к видеопамяти 2*n*sizeof(float) байт на чтение и 1*n*sizeof(float) байт на запись, т.е. итого 3*n*sizeof(float) байт
         // - В гигабайте 1024*1024*1024 байт
         // - Среднее время выполнения кернела равно t.lapAvg() секунд
-        std::cout << "VRAM bandwidth: " << 0 << " GB/s" << std::endl;
+        std::cout << "VRAM bandwidth: " << 3 * sizeof(float) * n / t.lapAvg() / (1 << 30) << " GB/s" << std::endl;
     }
 
     // TODO 15 Скачайте результаты вычислений из видеопамяти (VRAM) в оперативную память (RAM) - из cs_gpu в cs (и рассчитайте скорость трансфера данных в гигабайтах в секунду)
     {
         timer t;
         for (unsigned int i = 0; i < 20; ++i) {
-            // clEnqueueReadBuffer...
+            OCL_SAFE_CALL(
+                clEnqueueReadBuffer(command_queue, output, true, 0, sizeof(float) * n, cs.data(), 0, NULL, NULL));
             t.nextLap();
         }
         std::cout << "Result data transfer time: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "VRAM -> RAM bandwidth: " << 0 << " GB/s" << std::endl;
+        std::cout << "VRAM -> RAM bandwidth: " << sizeof(float) * n / t.lapAvg() / (1 << 30) << " GB/s" << std::endl;
     }
 
     // TODO 16 Сверьте результаты вычислений со сложением чисел на процессоре (и убедитесь, что если в кернеле сделать намеренную ошибку, то эта проверка поймает ошибку)
-//    for (unsigned int i = 0; i < n; ++i) {
-//        if (cs[i] != as[i] + bs[i]) {
-//            throw std::runtime_error("CPU and GPU results differ!");
-//        }
-//    }
+    for (unsigned int i = 0; i < n; ++i) {
+        if (cs[i] != as[i] + bs[i]) {
+            throw std::runtime_error("CPU and GPU results differ!");
+        }
+    }
+
+    clReleaseContext(context);
+    clReleaseCommandQueue(command_queue);
+    clReleaseMemObject(numbers1);
+    clReleaseMemObject(numbers2);
+    clReleaseMemObject(output);
+    clReleaseProgram(program);
+    clReleaseKernel(kernel);
 
     return 0;
 }


### PR DESCRIPTION
<details><summary>Локальный Вывод</summary><p>

<pre>
Data generated for n=100000000!

Kernel Sources:
#ifdef __CLION_IDE__
// Этот include виден только для CLion парсера, это позволяет IDE "знать" ключевые слова вроде __kernel, __global
// а также уметь подсказывать OpenCL методы, описанные в данном инклюде (такие как get_global_id(...) и get_local_id(...))
#include "clion_defines.cl"
#endif

#line 8 // Седьмая строчка теперь восьмая (при ошибках компиляции в логе компиляции будут указаны корректные строчки благодаря этой директиве)

// TODO 5 реализуйте кернел:
// - От обычной функции кернел отличается модификатором __kernel и тем, что возвращаемый тип всегда void
// - На вход дано три массива float чисел; единственное, чем они отличаются от обычных указателей - модификатором __global, т.к. это глобальная память устройства (видеопамять)
// - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное, чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)

__kernel void aplusb(__global float* src1, __global float* src2, __global float* dst, unsigned int n)
{
  // Узнать, какой workItem выполняется в этом потоке поможет функция get_global_id
  // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
  // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
  const unsigned int index = get_global_id(0);
  if (index >= n) {
    return;
  }
  dst[index] = src1[index] + src2[index];

  // P.S. В общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
  // и в таком случае, если сделать обращение к массиву просто по индексу=get_global_id(0), будет undefined behaviour (вплоть до повисания ОС)
  // поэтому нужно либо дополнить массив данных длиной до кратности размеру рабочей группы,
  // либо сделать return в кернеле до обращения к данным в тех WorkItems, где get_global_id(0) выходит за границы данных (явной проверкой)
}


Kernel Build Log:


Kernel average time: 0.0397868+-0.000666976 s
GFlops: 2.51339
VRAM bandwidth: 28.0894 GB/s
Result data transfer time: 0.0644922+-0.000619515 s
VRAM -> RAM bandwidth: 5.77635 GB/s
</pre>

</p></details>


<details><summary>Вывод Travis CI</summary><p>

<pre>
$ ./build/aplusb
Data generated for n=100000000!
Kernel Sources:
#ifdef __CLION_IDE__
// Этот include виден только для CLion парсера, это позволяет IDE "знать" ключевые слова вроде __kernel, __global
// а также уметь подсказывать OpenCL методы, описанные в данном инклюде (такие как get_global_id(...) и get_local_id(...))
#include "clion_defines.cl"
#endif
#line 8 // Седьмая строчка теперь восьмая (при ошибках компиляции в логе компиляции будут указаны корректные строчки благодаря этой директиве)
// TODO 5 реализуйте кернел:
// - От обычной функции кернел отличается модификатором __kernel и тем, что возвращаемый тип всегда void
// - На вход дано три массива float чисел; единственное, чем они отличаются от обычных указателей - модификатором __global, т.к. это глобальная память устройства (видеопамять)
// - Четвертым и последним аргументом должно быть передано количество элементов в каждом массиве (unsigned int, главное, чтобы тип был согласован с типом в соответствующем clSetKernelArg в T0D0 10)
__kernel void aplusb(__global float* src1, __global float* src2, __global float* dst, unsigned int n)
{
  // Узнать, какой workItem выполняется в этом потоке поможет функция get_global_id
  // см. в документации https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/
  // OpenCL Compiler -> Built-in Functions -> Work-Item Functions
  const unsigned int index = get_global_id(0);
  if (index >= n) {
    return;
  }
  dst[index] = src1[index] + src2[index];
  // P.S. В общем случае количество элементов для сложения может быть некратно размеру WorkGroup, тогда размер рабочего пространства округлен вверх от числа элементов до кратности на размер WorkGroup
  // и в таком случае, если сделать обращение к массиву просто по индексу=get_global_id(0), будет undefined behaviour (вплоть до повисания ОС)
  // поэтому нужно либо дополнить массив данных длиной до кратности размеру рабочей группы,
  // либо сделать return в кернеле до обращения к данным в тех WorkItems, где get_global_id(0) выходит за границы данных (явной проверкой)
}
Kernel Build Log:
Compilation started
Compilation done
Linking started
Linking done
Device build started
Device build done
Kernel <aplusb> was successfully vectorized (8)
Done.
Kernel average time: 0.0959754+-0.000787026 s
GFlops: 1.04193
VRAM bandwidth: 11.6445 GB/s
Result data transfer time: 0.110891+-0.000549747 s
VRAM -> RAM bandwidth: 3.35943 GB/s
</pre>

</p></details>