### PR TITLE
Task03 Валерий Миронов CSC

### DIFF
--- a/libs/gpu/libgpu/opencl/engine.cpp
+++ b/libs/gpu/libgpu/opencl/engine.cpp
@@ -432,9 +432,7 @@ const VersionedBinary* ProgramBinaries::getBinary(const std::shared_ptr<OpenCLEn
 
 		return binary;
 	}
-
-	throw ocl_exception("No SPIR version for " + to_string(cl->deviceAddressBits()) + "-bit device with OpenCL "
-						+ to_string(cl->deviceInfo().opencl_major_version) + "." + to_string(cl->deviceInfo().opencl_minor_version) + "!");
+	return binaries_.data(); // Fix for OpenCL 1.1
 }
 
 KernelSource::KernelSource(std::shared_ptr<ocl::ProgramBinaries> program, const char *name) : program_(program)

--- a/libs/utils/libutils/thread_mutex.h
+++ b/libs/utils/libutils/thread_mutex.h
@@ -91,6 +91,7 @@ public:
 	bool acquire ()
 	{
 		_locked = _mutex.tryLock();
+                return _locked;
 	}
 
 	void release ()

--- a/src/cl/mandelbrot.cl
+++ b/src/cl/mandelbrot.cl
@@ -1,13 +1,36 @@
 #ifdef __CLION_IDE__
-#include <libgpu/opencl/cl/clion_defines.cl>
+    #include <libgpu/opencl/cl/clion_defines.cl>
 #endif
 
 #line 6
 
-__kernel void mandelbrot(...)
-{
-    // TODO если хочется избавиться от зернистости и дрожания при интерактивном погружении, добавьте anti-aliasing:
-    // грубо говоря, при anti-aliasing уровня N вам нужно рассчитать не одно значение в центре пикселя, а N*N значений
-    // в узлах регулярной решетки внутри пикселя, а затем посчитав среднее значение результатов - взять его за результат для всего пикселя
-    // это увеличит число операций в N*N раз, поэтому при рассчетах гигаплопс антиальясинг должен быть выключен
+__kernel void mandelbrot(__global float *results, unsigned int width, unsigned int height, float fromX, float fromY,
+                         float sizeX, float sizeY, unsigned int iters, unsigned int smoothing) {
+    const float threshold = 256.0f;
+    const float threshold2 = threshold * threshold;
+
+    size_t i = get_global_id(0);
+    size_t j = get_global_id(1);
+
+    const float x0 = fromX + ((float) i + 0.5f) * sizeX / width;
+    const float y0 = fromY + ((float) j + 0.5f) * sizeY / height;
+
+    float x = x0;
+    float y = y0;
+
+    int iter = 0;
+    for (; iter < iters; ++iter) {
+        float xPrev = x;
+        x = x * x - y * y + x0;
+        y = 2.0f * xPrev * y + y0;
+        if ((x * x + y * y) > threshold2) {
+            break;
+        }
+    }
+    float result = iter;
+    if (smoothing == 1 && iter != iters) {
+        result -= log(log(sqrt(x * x + y * y)) / log(threshold)) / log(2.0f);
+    }
+    result = 1.0f * result / iters;
+    results[j * width + i] = result;
 }

--- a/src/cl/max_prefix_sum.cl
+++ b/src/cl/max_prefix_sum.cl
@@ -1,1 +1,43 @@
-// TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define LOCAL_SIZE 256
+
+__kernel void simpleMaxPrefixSum(__global const int *gSum, __global const int *gMaxSum, __global const uint *gResult,
+                                 __global int *gSumW, __global int *gMaxSumW, __global uint *gResultW, uint n) {
+    const uint globalId = get_global_id(0);
+    const uint localId = get_local_id(0);
+    const uint groupId = get_group_id(0);
+    __local int lSum[LOCAL_SIZE];
+    __local int lMaxSum[LOCAL_SIZE];
+    __local int lResult[LOCAL_SIZE];
+    if (globalId < n) {
+        lSum[localId] = gSum[globalId];
+        lMaxSum[localId] = gMaxSum[globalId];
+        lResult[localId] = gResult[globalId];
+    } else {
+        lSum[localId] = 0;
+        lMaxSum[localId] = 0;
+        lResult[localId] = 0;
+    }
+    barrier(CLK_LOCAL_MEM_FENCE);
+    if (localId == 0) {
+        int sum = 0;
+        int maxSum = -2147483648;
+        uint result = 0;
+        for (uint i = 0; i != LOCAL_SIZE; ++i) {
+            int temp = sum + lMaxSum[i];
+            if (temp > maxSum) {
+                maxSum = temp;
+                result = lResult[i];
+            }
+            sum += lSum[i];
+        }
+        gSumW[groupId] = sum;
+        gMaxSumW[groupId] = maxSum;
+        gResultW[groupId] = result;
+    }
+}

--- a/src/cl/sum.cl
+++ b/src/cl/sum.cl
@@ -1,1 +1,23 @@
-// TODO
+#ifdef __CLION_IDE__
+    #include <libgpu/opencl/cl/clion_defines.cl>
+#endif
+
+#line 6
+
+#define LOCAL_SIZE 256
+
+__kernel void sum(__global const uint *as, __global uint *result) {
+    const uint globalId = get_global_id(0);
+    const uint localId = get_local_id(0);
+    __local uint localAs[LOCAL_SIZE];
+    localAs[localId] = as[globalId];
+    for (uint offset = LOCAL_SIZE / 2; offset != 0; offset /= 2) {
+        barrier(CLK_LOCAL_MEM_FENCE);
+        if (localId < offset) {
+            localAs[localId] += localAs[localId + offset];
+        }
+    }
+    if (localId == 0) {
+        atomic_add(result, localAs[0]);
+    }
+}

--- a/src/main_mandelbrot.cpp
+++ b/src/main_mandelbrot.cpp
@@ -1,24 +1,20 @@
 #include <cmath>
 
-#include <libutils/misc.h>
-#include <libutils/timer.h>
 #include <libgpu/context.h>
 #include <libgpu/shared_device_buffer.h>
 #include <libimages/images.h>
+#include <libutils/misc.h>
+#include <libutils/timer.h>
 
 #include "cl/mandelbrot_cl.h"
 
 
-void mandelbrotCPU(float* results,
-                   unsigned int width, unsigned int height,
-                   float fromX, float fromY,
-                   float sizeX, float sizeY,
-                   unsigned int iters, bool smoothing)
-{
+void mandelbrotCPU(float *results, unsigned int width, unsigned int height, float fromX, float fromY, float sizeX,
+                   float sizeY, unsigned int iters, bool smoothing) {
     const float threshold = 256.0f;
     const float threshold2 = threshold * threshold;
-    
-    #pragma omp parallel for
+
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             float x0 = fromX + (i + 0.5f) * sizeX / width;
@@ -38,7 +34,7 @@ void mandelbrotCPU(float* results,
             }
             float result = iter;
             if (smoothing && iter != iters) {
-                result = result - logf(logf(sqrtf(x * x + y * y)) / logf(threshold)) / logf(2.0f);
+                result -= logf(logf(sqrtf(x * x + y * y)) / logf(threshold)) / logf(2.0f);
             }
 
             result = 1.0f * result / iters;
@@ -47,14 +43,16 @@ void mandelbrotCPU(float* results,
     }
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb, unsigned int width, unsigned int height);
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height);
 
 void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU);
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
     gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    gpu::Context context;
+    context.init(device.device_id_opencl);
+    context.activate();
 
     unsigned int benchmarkingIters = 10;
 
@@ -66,92 +64,103 @@ int main(int argc, char **argv)
     float centralY = -0.150316f;
     float sizeX = 0.00239f;
 
-//    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
-//    float centralX = -0.5f;
-//    float centralY = 0.0f;
-//    float sizeX = 2.0f;
+    // Менее красивый ракурс, но в этом ракурсе виден весь фрактал:
+    // float centralX = -0.5f;
+    // float centralY = 0.0f;
+    // float sizeX = 2.0f;
 
-    images::Image<float> cpu_results(width, height, 1);
-    images::Image<float> gpu_results(width, height, 1);
+    // Это бонус ввиде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть в какой момент числа итераций/точности single float перестанет хватать
+    // Кликами мышки можно смещать ракурс
+    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы
+    // bool useGPU = true;
+    // renderInWindow(centralX, centralY, iterationsLimit, useGPU);
+
+    images::Image<float> cpuResults(width, height, 1);
+    images::Image<float> gpuResults(width, height, 1);
     images::Image<unsigned char> image(width, height, 3);
 
     float sizeY = sizeX * height / width;
-
+    bool smoothing = false;
     {
         timer t;
         for (int i = 0; i < benchmarkingIters; ++i) {
-            mandelbrotCPU(cpu_results.ptr(),
-                          width, height,
-                          centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                          sizeX, sizeY,
-                          iterationsLimit, false);
+            mandelbrotCPU(cpuResults.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX,
+                          sizeY, iterationsLimit, smoothing);
             t.nextLap();
         }
         size_t flopsInLoop = 10;
         size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
-        size_t gflops = 1000*1000*1000;
+        size_t gflops = 1000 * 1000 * 1000;
         std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
         std::cout << "CPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
 
         double realIterationsFraction = 0.0;
         for (int j = 0; j < height; ++j) {
             for (int i = 0; i < width; ++i) {
-                realIterationsFraction += cpu_results.ptr()[j * width + i];
+                realIterationsFraction += cpuResults.ptr()[j * width + i];
             }
         }
-        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%" << std::endl;
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                  << std::endl;
 
-        renderToColor(cpu_results.ptr(), image.ptr(), width, height);
+        renderToColor(cpuResults.ptr(), image.ptr(), width, height);
         image.savePNG("mandelbrot_cpu.png");
     }
-
-
-//    // Раскомментируйте это:
-//
-//    gpu::Context context;
-//    context.init(device.device_id_opencl);
-//    context.activate();
-//    {
-//        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
-//        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
-//        // передав printLog=true - скорее всего, в логе будет строчка вроде
-//        // Kernel <mandelbrot> was successfully vectorized (8)
-//        // это означает, что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
-//        // это означает, что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float, то
-//        // это означает, что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
-//        // обратите внимание, что и произвдительность относительно референсной ЦПУ реализации выросла почти в восемь раз
-//        bool printLog = false;
-//        kernel.compile(printLog);
-//        // TODO близко к ЦПУ-версии, включая рассчет таймингов, гигафлопс, Real iterations fraction и сохранение в файл
-//        // результат должен оказаться в gpu_results
-//    }
-//
-//    {
-//        double errorAvg = 0.0;
-//        for (int j = 0; j < height; ++j) {
-//            for (int i = 0; i < width; ++i) {
-//                errorAvg += fabs(gpu_results.ptr()[j * width + i] - cpu_results.ptr()[j * width + i]);
-//            }
-//        }
-//        errorAvg /= width * height;
-//        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
-//
-//        if (errorAvg > 0.03) {
-//            throw std::runtime_error("Too high difference between CPU and GPU results!");
-//        }
-//    }
-
-    // Это бонус в виде интерактивной отрисовки, не забудьте запустить на ГПУ, чтобы посмотреть, в какой момент числа итераций/точности single float перестанет хватать
-    // Кликами мышки можно смещать ракурс
-    // Но в Pull-request эти две строки должны быть закомментированы, т.к. на автоматическом тестировании нет оконной подсистемы 
-//    bool useGPU = false;
-//    renderInWindow(centralX, centralY, iterationsLimit, useGPU);
-
+    {
+        // Если у вас есть интеловский драйвер для запуска на процессоре - попробуйте запустить на нем и взгляните на лог,
+        // передав printLog=true - скорее всего в логе будет строчка вроде
+        // Kernel <mandelbrot> was successfully vectorized (8)
+        // это означает что драйвер смог векторизовать вычисления с помощью интринсик, и если множитель векторизации 8, то
+        // это означает что одно ядро процессит сразу 8 workItems, а т.к. все вычисления в float,
+        // то это означает что используются 8 x float регистры (т.е. 256-битные, т.е. AVX)
+        // обратите внимание что и производительность относительно референсной ЦПУ реализации выросла почти в восемь раз
+        ocl::Kernel kernel(mandelbrot_kernel, mandelbrot_kernel_length, "mandelbrot");
+        bool printLog = false;
+        kernel.compile(printLog);
+        gpu::gpu_mem_32f imgBuf;
+        imgBuf.resizeN(gpuResults.width * gpuResults.height);
+        unsigned int workGroupSize = 16;
+        timer t;
+        for (int i = 0; i < benchmarkingIters; ++i) {
+            kernel.exec(gpu::WorkSize(workGroupSize * workGroupSize, 1, width, height), imgBuf, width, height,
+                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit,
+                        int(smoothing));
+            t.nextLap();
+        }
+        size_t flopsInLoop = 10;
+        size_t maxApproximateFlops = width * height * iterationsLimit * flopsInLoop;
+        size_t gflops = 1000 * 1000 * 1000;
+        std::cout << "GPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU: " << maxApproximateFlops / gflops / t.lapAvg() << " GFlops" << std::endl;
+        imgBuf.readN(gpuResults.ptr(), gpuResults.width * gpuResults.height);
+        double realIterationsFraction = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                realIterationsFraction += gpuResults.ptr()[j * width + i];
+            }
+        }
+        std::cout << "    Real iterations fraction: " << 100.0 * realIterationsFraction / (width * height) << "%"
+                  << std::endl;
+        renderToColor(gpuResults.ptr(), image.ptr(), width, height);
+        image.savePNG("mandelbrot_gpu.png");
+    }
+    {
+        double errorAvg = 0.0;
+        for (int j = 0; j < height; ++j) {
+            for (int i = 0; i < width; ++i) {
+                errorAvg += std::abs(gpuResults.ptr()[j * width + i] - cpuResults.ptr()[j * width + i]);
+            }
+        }
+        errorAvg /= width * height;
+        std::cout << "GPU vs CPU average results difference: " << 100.0 * errorAvg << "%" << std::endl;
+        if (errorAvg > 0.03) {
+            throw std::runtime_error("Too high difference between CPU and GPU results!");
+        }
+    }
     return 0;
 }
 
-void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU)
-{
+void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit, bool useGPU) {
     images::ImageWindow window("Mandelbrot");
 
     unsigned int width = 1024;
@@ -174,16 +183,11 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
 
     do {
         if (!useGPU) {
-            mandelbrotCPU(results.ptr(), width, height,
-                          centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                          sizeX, sizeY,
+            mandelbrotCPU(results.ptr(), width, height, centralX - sizeX / 2.0f, centralY - sizeY / 2.0f, sizeX, sizeY,
                           iterationsLimit, true);
         } else {
-            kernel.exec(gpu::WorkSize(16, 16, width, height),
-                        results_vram, width, height,
-                        centralX - sizeX / 2.0f, centralY - sizeY / 2.0f,
-                        sizeX, sizeY,
-                        iterationsLimit, 1);
+            kernel.exec(gpu::WorkSize(16, 16, width, height), results_vram, width, height, centralX - sizeX / 2.0f,
+                        centralY - sizeY / 2.0f, sizeX, sizeY, iterationsLimit, 1);
             results_vram.readN(results.ptr(), width * height);
         }
         renderToColor(results.ptr(), image.ptr(), width, height);
@@ -194,7 +198,7 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
         if (window.getMouseClick() == MOUSE_LEFT) {
             centralX = centralX - sizeX * 0.5f + sizeX * window.getMouseX() / width;
             centralY = centralY - sizeY * 0.5f + sizeY * window.getMouseY() / height;
-            std::cout << "Focus: " << centralX << " " << centralY  << " " << sizeX << std::endl;
+            std::cout << "Focus: " << centralX << " " << centralY << " " << sizeX << std::endl;
         }
         if (window.isResized()) {
             window.resize();
@@ -218,9 +222,12 @@ void renderInWindow(float centralX, float centralY, unsigned int iterationsLimit
 
 
 struct vec3f {
-    vec3f(float x, float y, float z) : x(x), y(y), z(z) {}
+    vec3f(float x, float y, float z) : x(x), y(y), z(z) {
+    }
 
-    float x; float y; float z;
+    float x;
+    float y;
+    float z;
 };
 
 vec3f operator+(const vec3f &a, const vec3f &b) {
@@ -247,10 +254,8 @@ vec3f cos(const vec3f &a) {
     return {cosf(a.x), cosf(a.y), cosf(a.z)};
 }
 
-void renderToColor(const float* results, unsigned char* img_rgb,
-             unsigned int width, unsigned int height)
-{
-    #pragma omp parallel for
+void renderToColor(const float *results, unsigned char *img_rgb, unsigned int width, unsigned int height) {
+#pragma omp parallel for
     for (int j = 0; j < height; ++j) {
         for (int i = 0; i < width; ++i) {
             // Палитра взята отсюда: http://iquilezles.org/www/articles/palettes/palettes.htm
@@ -259,7 +264,7 @@ void renderToColor(const float* results, unsigned char* img_rgb,
             vec3f b(0.5, 0.5, 0.5);
             vec3f c(1.0, 0.7, 0.4);
             vec3f d(0.00, 0.15, 0.20);
-            vec3f color = a + b * cos(2*3.14f*(c*t+d));
+            vec3f color = a + b * cos(2 * 3.14f * (c * t + d));
             img_rgb[j * 3 * width + i * 3 + 0] = (unsigned char) (color.x * 255);
             img_rgb[j * 3 * width + i * 3 + 1] = (unsigned char) (color.y * 255);
             img_rgb[j * 3 * width + i * 3 + 2] = (unsigned char) (color.z * 255);

--- a/src/main_max_prefix_sum.cpp
+++ b/src/main_max_prefix_sum.cpp
@@ -1,11 +1,13 @@
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
 
+#include "cl/max_prefix_sum_cl.h"
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
     if (a != b) {
         std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
         throw std::runtime_error(message);
@@ -15,55 +17,49 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+    unsigned int workGroupSize = 256;
     int benchmarkingIters = 10;
-    int max_n = (1 << 24);
+    int maxN = (1 << 24);
 
-    for (int n = 2; n <= max_n; n *= 2) {
+    for (int n = 2; n <= maxN; n *= 2) {
+        unsigned int globalWorkSize = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
         std::cout << "______________________________________________" << std::endl;
-        int values_range = std::min(1023, std::numeric_limits<int>::max() / n);
-        std::cout << "n=" << n << " values in range: [" << (-values_range) << "; " << values_range << "]" << std::endl;
-
-        std::vector<int> as(n, 0);
-        FastRandom r(n);
-        for (int i = 0; i < n; ++i) {
-            as[i] = r.next(-values_range, values_range);
-        }
-
-        int reference_max_sum;
-        int reference_result;
+        int valuesRange = std::min(1023, std::numeric_limits<int>::max() / n);
+        std::cout << "n=" << n << " values in range: [" << (-valuesRange) << "; " << valuesRange << "]" << std::endl;
+        std::vector<int> as(globalWorkSize, 0);
+        int referenceMaxSum = std::numeric_limits<int>::min();
+        unsigned int referenceResult = 0;
         {
-            int max_sum = 0;
+            FastRandom r(n);
             int sum = 0;
-            int result = 0;
-            for (int i = 0; i < n; ++i) {
+            for (unsigned int i = 0; i < n; ++i) {
+                as[i] = r.next(-valuesRange, valuesRange);
                 sum += as[i];
-                if (sum > max_sum) {
-                    max_sum = sum;
-                    result = i + 1;
+                if (sum > referenceMaxSum) {
+                    referenceMaxSum = sum;
+                    referenceResult = i + 1;
                 }
             }
-            reference_max_sum = max_sum;
-            reference_result = result;
+            std::cout << "Max prefix sum: " << referenceMaxSum << " on prefix [0; " << referenceResult << ")"
+                      << std::endl;
         }
-        std::cout << "Max prefix sum: " << reference_max_sum << " on prefix [0; " << reference_result << ")" << std::endl;
-
         {
             timer t;
             for (int iter = 0; iter < benchmarkingIters; ++iter) {
-                int max_sum = 0;
+                int maxSum = std::numeric_limits<int>::min();
+                unsigned int result = 0;
                 int sum = 0;
-                int result = 0;
-                for (int i = 0; i < n; ++i) {
+                for (unsigned int i = 0; i < n; ++i) {
                     sum += as[i];
-                    if (sum > max_sum) {
-                        max_sum = sum;
+                    if (sum > maxSum) {
+                        maxSum = sum;
                         result = i + 1;
                     }
                 }
-                EXPECT_THE_SAME(reference_max_sum, max_sum, "CPU result should be consistent!");
-                EXPECT_THE_SAME(reference_result, result, "CPU result should be consistent!");
+                EXPECT_THE_SAME(referenceMaxSum, maxSum, "CPU result should be consistent!");
+                EXPECT_THE_SAME(referenceResult, result, "CPU result should be consistent!");
                 t.nextLap();
             }
             std::cout << "CPU: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
@@ -71,7 +67,61 @@ int main(int argc, char **argv)
         }
 
         {
-            // TODO: implement on OpenCL
+            gpu::Context context;
+            context.init(device.device_id_opencl);
+            context.activate();
+
+            ocl::Kernel simpleMaxPrefixSum(max_prefix_sum_kernel, max_prefix_sum_kernel_length, "simpleMaxPrefixSum");
+            simpleMaxPrefixSum.compile();
+
+            auto sumGpu = gpu::gpu_mem_32i::createN(globalWorkSize);
+            auto maxSumGpu = gpu::gpu_mem_32i::createN(globalWorkSize);
+            auto resultGpu = gpu::gpu_mem_32u::createN(globalWorkSize);
+
+            auto sumGpu2 = gpu::gpu_mem_32i::createN(globalWorkSize);
+            auto maxSumGpu2 = gpu::gpu_mem_32i::createN(globalWorkSize);
+            auto resultGpu2 = gpu::gpu_mem_32u::createN(globalWorkSize);
+
+            auto sumGpu3 = gpu::gpu_mem_32i::createN(globalWorkSize);
+            auto maxSumGpu3 = gpu::gpu_mem_32i::createN(globalWorkSize);
+            auto resultGpu3 = gpu::gpu_mem_32u::createN(globalWorkSize);
+
+            sumGpu.writeN(as.data(), n);
+            maxSumGpu.writeN(as.data(), n);
+            {
+                std::vector<unsigned int> result(globalWorkSize, 0);
+                for (unsigned int i = 0; i != n; ++i) {
+                    result[i] = i + 1;
+                }
+                resultGpu.writeN(result.data(), globalWorkSize);
+            }
+            sumGpu.copyToN(sumGpu2, globalWorkSize);
+            maxSumGpu.copyToN(maxSumGpu2, globalWorkSize);
+            resultGpu.copyToN(resultGpu2, globalWorkSize);
+            timer t;
+            for (int iter = 0; iter < benchmarkingIters; ++iter) {
+                t.restart();
+                for (auto workSize = n; workSize > 1; workSize = (workSize + workGroupSize - 1) / workGroupSize) {
+                    simpleMaxPrefixSum.exec(gpu::WorkSize(workGroupSize, workSize), sumGpu2, maxSumGpu2, resultGpu2,
+                                            sumGpu3, maxSumGpu3, resultGpu3, workSize);
+                    sumGpu2.swap(sumGpu3);
+                    maxSumGpu2.swap(maxSumGpu3);
+                    resultGpu2.swap(resultGpu3);
+                }
+                t.stop();
+                t.nextLap();
+                int maxSum = std::numeric_limits<int>::min();
+                maxSumGpu2.readN(&maxSum, 1);
+                EXPECT_THE_SAME(referenceMaxSum, maxSum, "GPU result should be consistent!");
+                unsigned int result = 0;
+                resultGpu2.readN(&result, 1);
+                EXPECT_THE_SAME(referenceResult, result, "GPU result should be consistent!");
+                sumGpu.copyToN(sumGpu2, globalWorkSize);
+                maxSumGpu.copyToN(maxSumGpu2, globalWorkSize);
+                resultGpu.copyToN(resultGpu2, globalWorkSize);
+            }
+            std::cout << "GPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+            std::cout << "GPU:     " << (globalWorkSize / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
         }
     }
 }

--- a/src/main_sum.cpp
+++ b/src/main_sum.cpp
@@ -1,11 +1,14 @@
+#include <libgpu/context.h>
+#include <libgpu/shared_device_buffer.h>
+#include <libutils/fast_random.h>
 #include <libutils/misc.h>
 #include <libutils/timer.h>
-#include <libutils/fast_random.h>
+
+#include "cl/sum_cl.h"
 
 
 template<typename T>
-void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line)
-{
+void raiseFail(const T &a, const T &b, std::string message, std::string filename, int line) {
     if (a != b) {
         std::cerr << message << " But " << a << " != " << b << ", " << filename << ":" << line << std::endl;
         throw std::runtime_error(message);
@@ -15,17 +18,19 @@ void raiseFail(const T &a, const T &b, std::string message, std::string filename
 #define EXPECT_THE_SAME(a, b, message) raiseFail(a, b, message, __FILE__, __LINE__)
 
 
-int main(int argc, char **argv)
-{
+int main(int argc, char **argv) {
+    gpu::Device device = gpu::chooseGPUDevice(argc, argv);
     int benchmarkingIters = 10;
 
-    unsigned int reference_sum = 0;
-    unsigned int n = 100*1000*1000;
-    std::vector<unsigned int> as(n, 0);
+    unsigned int referenceSum = 0;
+    unsigned int n = 100 * 1000 * 1000;
+    unsigned int workGroupSize = 256;
+    unsigned int globalWorkSize = (n + workGroupSize - 1) / workGroupSize * workGroupSize;
+    std::vector<unsigned int> as(globalWorkSize, 0);
     FastRandom r(42);
     for (int i = 0; i < n; ++i) {
         as[i] = (unsigned int) r.next(0, std::numeric_limits<unsigned int>::max() / n);
-        reference_sum += as[i];
+        referenceSum += as[i];
     }
 
     {
@@ -35,30 +40,49 @@ int main(int argc, char **argv)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
-            EXPECT_THE_SAME(reference_sum, sum, "CPU result should be consistent!");
+            EXPECT_THE_SAME(referenceSum, sum, "CPU result should be consistent!");
             t.nextLap();
         }
         std::cout << "CPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU:     " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU:     " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
         timer t;
         for (int iter = 0; iter < benchmarkingIters; ++iter) {
             unsigned int sum = 0;
-            #pragma omp parallel for reduction(+:sum)
+#pragma omp parallel for reduction(+ : sum)
             for (int i = 0; i < n; ++i) {
                 sum += as[i];
             }
-            EXPECT_THE_SAME(reference_sum, sum, "CPU OpenMP result should be consistent!");
+            EXPECT_THE_SAME(referenceSum, sum, "CPU OpenMP result should be consistent!");
             t.nextLap();
         }
         std::cout << "CPU OMP: " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
-        std::cout << "CPU OMP: " << (n/1000.0/1000.0) / t.lapAvg() << " millions/s" << std::endl;
+        std::cout << "CPU OMP: " << (n / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 
     {
-        // TODO: implement on OpenCL
-        // gpu::Device device = gpu::chooseGPUDevice(argc, argv);
+        gpu::Context context;
+        context.init(device.device_id_opencl);
+        context.activate();
+        ocl::Kernel sum(sum_kernel, sum_kernel_length, "sum");
+        sum.compile();
+        auto sumGpu = gpu::gpu_mem_32u::createN(1);
+        auto asGpu = gpu::gpu_mem_32u::createN(globalWorkSize);
+        asGpu.writeN(as.data(), globalWorkSize);
+        timer t;
+        for (int iter = 0; iter < benchmarkingIters; ++iter) {
+            unsigned int sumResult = 0;
+            sumGpu.writeN(&sumResult, 1);
+            t.restart();
+            sum.exec(gpu::WorkSize(workGroupSize, globalWorkSize), asGpu, sumGpu);
+            t.stop();
+            t.nextLap();
+            sumGpu.readN(&sumResult, 1);
+            EXPECT_THE_SAME(referenceSum, sumResult, "CPU result should be consistent!");
+        }
+        std::cout << "GPU:     " << t.lapAvg() << "+-" << t.lapStd() << " s" << std::endl;
+        std::cout << "GPU:     " << (globalWorkSize / 1000.0 / 1000.0) / t.lapAvg() << " millions/s" << std::endl;
     }
 }


### PR DESCRIPTION
<details><summary>Локальный вывод mandelbrot Intel HD</summary><p>
<pre>
Using device #0: GPU. Intel(R) UHD Graphics 620 [0x5917]. Total memory: 12618 Mb
CPU: 0.444517+-0.00135514 s
CPU: 22.4963 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.0579088+-0.000531025 s
GPU: 172.685 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>
</p></details>

<details><summary>Локальный вывод mandelbrot AMD GPU</summary><p>
<pre>
Using device #1: GPU. Radeon 500 Series (POLARIS12, DRM 3.40.0, 5.10.70-1-lts, LLVM 12.0.1). Total memory: 3072 Mb
CPU: 0.570963+-0.0718678 s
CPU: 17.5143 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.0314885+-1.00623e-05 s
GPU: 317.576 GFlops
    Real iterations fraction: 56.2638%
GPU vs CPU average results difference: 0%
</pre>
</p></details>

<details><summary>Локальный вывод mandelbrot POCL</summary><p>
<pre>
Using device #2: CPU. pthread-Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. GenuineIntel. Total memory: 13725 Mb
CPU: 0.432688+-0.000763271 s
CPU: 23.1113 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.295116+-0.00643029 s
GPU: 33.8849 GFlops
    Real iterations fraction: 56.2657%
GPU vs CPU average results difference: 0.942446%
</pre>
</p></details>

<details><summary>Локальный вывод sum Intel HD</summary><p>
<pre>
Using device #0: GPU. Intel(R) UHD Graphics 620 [0x5917]. Total memory: 12618 Mb
CPU:     0.0516377+-0.000213041 s
CPU:     1936.57 millions/s
CPU OMP: 0.0157425+-0.000203644 s
CPU OMP: 6352.23 millions/s
GPU:     0.0432578+-4.04698e-05 s
GPU:     2311.72 millions/s
</pre>
</p></details>

<details><summary>Локальный вывод sum AMD GPU</summary><p>
<pre>
Using device #1: GPU. Radeon 500 Series (POLARIS12, DRM 3.40.0, 5.10.70-1-lts, LLVM 12.0.1). Total memory: 3072 Mb
CPU:     0.0510462+-2.40792e-05 s
CPU:     1959.01 millions/s
CPU OMP: 0.014792+-0.000288654 s
CPU OMP: 6760.41 millions/s
GPU:     0.260024+-4.69139e-05 s
GPU:     384.581 millions/s
</pre>
</p></details>

<details><summary>Локальный вывод sum POCL</summary><p>
<pre>
Using device #2: CPU. pthread-Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. GenuineIntel. Total memory: 13725 Mb
CPU:     0.0514293+-2.52036e-05 s
CPU:     1944.42 millions/s
CPU OMP: 0.0142723+-0.000128727 s
CPU OMP: 7006.56 millions/s
GPU:     0.15778+-0.00105198 s
GPU:     633.792 millions/s
</pre>
</p></details>

<details><summary>Локальный вывод max prefix sum Intel HD</summary><p>
<pre>
Using device #0: GPU. Intel(R) UHD Graphics 620 [0x5917]. Total memory: 12618 Mb
______________________________________________
n=2 values in range: [-1023; 1023]
Max prefix sum: -517 on prefix [0; 2)
CPU: 0+-0 s
CPU: inf millions/s
GPU:     8.43333e-05+-4.71405e-07 s
GPU:     3.03557 millions/s
______________________________________________
n=4 values in range: [-1023; 1023]
Max prefix sum: 1014 on prefix [0; 2)
CPU: 0+-0 s
CPU: inf millions/s
GPU:     8.16667e-05+-4.71405e-07 s
GPU:     3.13469 millions/s
______________________________________________
n=8 values in range: [-1023; 1023]
Max prefix sum: -887 on prefix [0; 1)
CPU: 0+-0 s
CPU: inf millions/s
GPU:     8.2e-05+-5.7735e-07 s
GPU:     3.12195 millions/s
______________________________________________
n=16 values in range: [-1023; 1023]
Max prefix sum: 457 on prefix [0; 1)
CPU: 0+-0 s
CPU: inf millions/s
GPU:     8.18333e-05+-3.72678e-07 s
GPU:     3.12831 millions/s
______________________________________________
n=32 values in range: [-1023; 1023]
Max prefix sum: -51 on prefix [0; 1)
CPU: 0+-0 s
CPU: inf millions/s
GPU:     8.15e-05+-5e-07 s
GPU:     3.1411 millions/s
______________________________________________
n=64 values in range: [-1023; 1023]
Max prefix sum: 1170 on prefix [0; 17)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 384 millions/s
GPU:     8.76667e-05+-4.71405e-07 s
GPU:     2.92015 millions/s
______________________________________________
n=128 values in range: [-1023; 1023]
Max prefix sum: 4773 on prefix [0; 124)
CPU: 3.33333e-07+-4.71405e-07 s
CPU: 384 millions/s
GPU:     9.63333e-05+-4.71405e-07 s
GPU:     2.65744 millions/s
______________________________________________
n=256 values in range: [-1023; 1023]
Max prefix sum: 7649 on prefix [0; 183)
CPU: 3.33333e-07+-4.71405e-07 s
CPU: 768 millions/s
GPU:     9.73333e-05+-4.71405e-07 s
GPU:     2.63014 millions/s
______________________________________________
n=512 values in range: [-1023; 1023]
Max prefix sum: 4170 on prefix [0; 52)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 3072 millions/s
GPU:     0.000167167+-3.72678e-07 s
GPU:     3.06281 millions/s
______________________________________________
n=1024 values in range: [-1023; 1023]
Max prefix sum: 14708 on prefix [0; 829)
CPU: 1e-06+-0 s
CPU: 1024 millions/s
GPU:     0.000168333+-7.45356e-07 s
GPU:     6.08317 millions/s
______________________________________________
n=2048 values in range: [-1023; 1023]
Max prefix sum: 22303 on prefix [0; 1779)
CPU: 1.5e-06+-5e-07 s
CPU: 1365.33 millions/s
GPU:     0.000174833+-6.87184e-07 s
GPU:     11.714 millions/s
______________________________________________
n=4096 values in range: [-1023; 1023]
Max prefix sum: 4292 on prefix [0; 58)
CPU: 2.83333e-06+-3.72678e-07 s
CPU: 1445.65 millions/s
GPU:     0.000162167+-1.06719e-06 s
GPU:     25.258 millions/s
______________________________________________
n=8192 values in range: [-1023; 1023]
Max prefix sum: 3297 on prefix [0; 470)
CPU: 5e-06+-5.68434e-14 s
CPU: 1638.4 millions/s
GPU:     0.0001765+-7.63763e-07 s
GPU:     46.4136 millions/s
______________________________________________
n=16384 values in range: [-1023; 1023]
Max prefix sum: 103982 on prefix [0; 10101)
CPU: 1.21667e-05+-3.72678e-07 s
CPU: 1346.63 millions/s
GPU:     0.000186333+-4.71405e-07 s
GPU:     87.9284 millions/s
______________________________________________
n=32768 values in range: [-1023; 1023]
Max prefix sum: 75785 on prefix [0; 2074)
CPU: 2.1e-05+-0 s
CPU: 1560.38 millions/s
GPU:     0.000201333+-1.24722e-06 s
GPU:     162.755 millions/s
______________________________________________
n=65536 values in range: [-1023; 1023]
Max prefix sum: 93500 on prefix [0; 61715)
CPU: 4.01667e-05+-3.72678e-07 s
CPU: 1631.6 millions/s
GPU:     0.0002435+-1.11803e-06 s
GPU:     269.142 millions/s
______________________________________________
n=131072 values in range: [-1023; 1023]
Max prefix sum: 310443 on prefix [0; 102163)
CPU: 7.85e-05+-5.70818e-06 s
CPU: 1669.71 millions/s
GPU:     0.000416167+-6.66875e-06 s
GPU:     314.951 millions/s
______________________________________________
n=262144 values in range: [-1023; 1023]
Max prefix sum: 449686 on prefix [0; 211310)
CPU: 0.00016+-4.54606e-06 s
CPU: 1638.4 millions/s
GPU:     0.000595+-5.03322e-06 s
GPU:     440.578 millions/s
______________________________________________
n=524288 values in range: [-1023; 1023]
Max prefix sum: 18511 on prefix [0; 470827)
CPU: 0.000306+-9.12871e-06 s
CPU: 1713.36 millions/s
GPU:     0.0010095+-6.75154e-06 s
GPU:     519.354 millions/s
______________________________________________
n=1048576 values in range: [-1023; 1023]
Max prefix sum: 46638 on prefix [0; 12341)
CPU: 0.0005745+-6.47431e-06 s
CPU: 1825.2 millions/s
GPU:     0.0017915+-7.66002e-05 s
GPU:     585.306 millions/s
______________________________________________
n=2097152 values in range: [-1023; 1023]
Max prefix sum: 1199401 on prefix [0; 1691780)
CPU: 0.00164817+-1.82703e-05 s
CPU: 1272.42 millions/s
GPU:     0.00315683+-1.51703e-05 s
GPU:     664.321 millions/s
______________________________________________
n=4194304 values in range: [-511; 511]
Max prefix sum: 43576 on prefix [0; 3543860)
CPU: 0.00268467+-5.21749e-06 s
CPU: 1562.32 millions/s
GPU:     0.00596+-1.20692e-05 s
GPU:     703.742 millions/s
______________________________________________
n=8388608 values in range: [-255; 255]
Max prefix sum: 262168 on prefix [0; 2631415)
CPU: 0.0055035+-0.000116008 s
CPU: 1524.23 millions/s
GPU:     0.0116647+-3.00426e-05 s
GPU:     719.147 millions/s
______________________________________________
n=16777216 values in range: [-127; 127]
Max prefix sum: 79474 on prefix [0; 976207)
CPU: 0.0115823+-0.000412411 s
CPU: 1448.52 millions/s
GPU:     0.0231242+-0.000116054 s
GPU:     725.527 millions/s
</pre>
</p></details>

<details><summary>Локальный вывод max prefix sum AMD GPU</summary><p>
<pre>
Using device #1: GPU. Radeon 500 Series (POLARIS12, DRM 3.40.0, 5.10.70-1-lts, LLVM 12.0.1). Total memory: 3072 Mb
______________________________________________
n=2 values in range: [-1023; 1023]
Max prefix sum: -517 on prefix [0; 2)
CPU: 5e-07+-5e-07 s
CPU: 4 millions/s
GPU:     0.000120167+-3.13138e-06 s
GPU:     2.13037 millions/s
______________________________________________
n=4 values in range: [-1023; 1023]
Max prefix sum: 1014 on prefix [0; 2)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 24 millions/s
GPU:     0.0001195+-1.50083e-05 s
GPU:     2.14226 millions/s
______________________________________________
n=8 values in range: [-1023; 1023]
Max prefix sum: -887 on prefix [0; 1)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 48 millions/s
GPU:     0.000113167+-9.08142e-06 s
GPU:     2.26215 millions/s
______________________________________________
n=16 values in range: [-1023; 1023]
Max prefix sum: 457 on prefix [0; 1)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 96 millions/s
GPU:     0.000123833+-2.04892e-05 s
GPU:     2.06729 millions/s
______________________________________________
n=32 values in range: [-1023; 1023]
Max prefix sum: -51 on prefix [0; 1)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 192 millions/s
GPU:     0.000119+-1.16333e-05 s
GPU:     2.15126 millions/s
______________________________________________
n=64 values in range: [-1023; 1023]
Max prefix sum: 1170 on prefix [0; 17)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 384 millions/s
GPU:     0.000109167+-6.30916e-06 s
GPU:     2.34504 millions/s
______________________________________________
n=128 values in range: [-1023; 1023]
Max prefix sum: 4773 on prefix [0; 124)
CPU: 6.66667e-07+-4.71405e-07 s
CPU: 192 millions/s
GPU:     0.0001145+-1.3048e-05 s
GPU:     2.23581 millions/s
______________________________________________
n=256 values in range: [-1023; 1023]
Max prefix sum: 7649 on prefix [0; 183)
CPU: 5e-07+-5e-07 s
CPU: 512 millions/s
GPU:     0.000104833+-5.2731e-06 s
GPU:     2.44197 millions/s
______________________________________________
n=512 values in range: [-1023; 1023]
Max prefix sum: 4170 on prefix [0; 52)
CPU: 5e-07+-5e-07 s
CPU: 1024 millions/s
GPU:     0.000217333+-2.21786e-05 s
GPU:     2.35583 millions/s
______________________________________________
n=1024 values in range: [-1023; 1023]
Max prefix sum: 14708 on prefix [0; 829)
CPU: 1e-06+-0 s
CPU: 1024 millions/s
GPU:     0.000208833+-2.28139e-05 s
GPU:     4.90343 millions/s
______________________________________________
n=2048 values in range: [-1023; 1023]
Max prefix sum: 22303 on prefix [0; 1779)
CPU: 2.66667e-06+-4.71405e-07 s
CPU: 768 millions/s
GPU:     0.000204333+-1.05462e-05 s
GPU:     10.0228 millions/s
______________________________________________
n=4096 values in range: [-1023; 1023]
Max prefix sum: 4292 on prefix [0; 58)
CPU: 4.83333e-06+-3.72678e-07 s
CPU: 847.448 millions/s
GPU:     0.000212833+-2.62197e-05 s
GPU:     19.2451 millions/s
______________________________________________
n=8192 values in range: [-1023; 1023]
Max prefix sum: 3297 on prefix [0; 470)
CPU: 5e-06+-5.68434e-14 s
CPU: 1638.4 millions/s
GPU:     0.000222167+-2.5268e-05 s
GPU:     36.8732 millions/s
______________________________________________
n=16384 values in range: [-1023; 1023]
Max prefix sum: 103982 on prefix [0; 10101)
CPU: 1.1e-05+-2.27374e-13 s
CPU: 1489.45 millions/s
GPU:     0.0002245+-1.16726e-05 s
GPU:     72.98 millions/s
______________________________________________
n=32768 values in range: [-1023; 1023]
Max prefix sum: 75785 on prefix [0; 2074)
CPU: 2.3e-05+-0 s
CPU: 1424.7 millions/s
GPU:     0.000298+-3.92471e-05 s
GPU:     109.96 millions/s
______________________________________________
n=65536 values in range: [-1023; 1023]
Max prefix sum: 93500 on prefix [0; 61715)
CPU: 4.38333e-05+-6.87184e-07 s
CPU: 1495.12 millions/s
GPU:     0.000388333+-4.04296e-05 s
GPU:     168.762 millions/s
______________________________________________
n=131072 values in range: [-1023; 1023]
Max prefix sum: 310443 on prefix [0; 102163)
CPU: 8.73333e-05+-4.71405e-07 s
CPU: 1500.82 millions/s
GPU:     0.00067+-3.41028e-05 s
GPU:     195.63 millions/s
______________________________________________
n=262144 values in range: [-1023; 1023]
Max prefix sum: 449686 on prefix [0; 211310)
CPU: 0.000196333+-7.4087e-06 s
CPU: 1335.2 millions/s
GPU:     0.00137983+-0.000110453 s
GPU:     189.982 millions/s
______________________________________________
n=524288 values in range: [-1023; 1023]
Max prefix sum: 18511 on prefix [0; 470827)
CPU: 0.000684167+-2.54913e-05 s
CPU: 766.316 millions/s
GPU:     0.00181567+-7.43206e-05 s
GPU:     288.758 millions/s
______________________________________________
n=1048576 values in range: [-1023; 1023]
Max prefix sum: 46638 on prefix [0; 12341)
CPU: 0.000848167+-3.39432e-05 s
CPU: 1236.29 millions/s
GPU:     0.00358183+-0.000265503 s
GPU:     292.748 millions/s
______________________________________________
n=2097152 values in range: [-1023; 1023]
Max prefix sum: 1199401 on prefix [0; 1691780)
CPU: 0.0014515+-5.34345e-05 s
CPU: 1444.82 millions/s
GPU:     0.00591233+-8.09684e-05 s
GPU:     354.708 millions/s
______________________________________________
n=4194304 values in range: [-511; 511]
Max prefix sum: 43576 on prefix [0; 3543860)
CPU: 0.00285+-6.63752e-05 s
CPU: 1471.69 millions/s
GPU:     0.0107908+-3.38054e-05 s
GPU:     388.691 millions/s
______________________________________________
n=8388608 values in range: [-255; 255]
Max prefix sum: 262168 on prefix [0; 2631415)
CPU: 0.00606133+-0.000252512 s
CPU: 1383.95 millions/s
GPU:     0.020292+-5.99444e-05 s
GPU:     413.395 millions/s
______________________________________________
n=16777216 values in range: [-127; 127]
Max prefix sum: 79474 on prefix [0; 976207)
CPU: 0.0128975+-3.8621e-05 s
CPU: 1300.81 millions/s
GPU:     0.132718+-1.41853e-05 s
GPU:     126.412 millions/s
</pre>
</p></details>

<details><summary>Локальный вывод max prefix sum POCL</summary><p>
<pre>
Using device #2: CPU. pthread-Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz. GenuineIntel. Total memory: 13725 Mb
______________________________________________
n=2 values in range: [-1023; 1023]
Max prefix sum: -517 on prefix [0; 2)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 12 millions/s
GPU:     4.81667e-05+-8.51306e-06 s
GPU:     5.31488 millions/s
______________________________________________
n=4 values in range: [-1023; 1023]
Max prefix sum: 1014 on prefix [0; 2)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 24 millions/s
GPU:     3.86667e-05+-1.10554e-06 s
GPU:     6.62069 millions/s
______________________________________________
n=8 values in range: [-1023; 1023]
Max prefix sum: -887 on prefix [0; 1)
CPU: 0+-0 s
CPU: inf millions/s
GPU:     3.91667e-05+-1.34371e-06 s
GPU:     6.53617 millions/s
______________________________________________
n=16 values in range: [-1023; 1023]
Max prefix sum: 457 on prefix [0; 1)
CPU: 0+-0 s
CPU: inf millions/s
GPU:     3.66667e-05+-4.71405e-07 s
GPU:     6.98182 millions/s
______________________________________________
n=32 values in range: [-1023; 1023]
Max prefix sum: -51 on prefix [0; 1)
CPU: 0+-0 s
CPU: inf millions/s
GPU:     3.86667e-05+-3.44803e-06 s
GPU:     6.62069 millions/s
______________________________________________
n=64 values in range: [-1023; 1023]
Max prefix sum: 1170 on prefix [0; 17)
CPU: 0+-0 s
CPU: inf millions/s
GPU:     3.8e-05+-8.16497e-07 s
GPU:     6.73684 millions/s
______________________________________________
n=128 values in range: [-1023; 1023]
Max prefix sum: 4773 on prefix [0; 124)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 768 millions/s
GPU:     4e-05+-2.23607e-06 s
GPU:     6.4 millions/s
______________________________________________
n=256 values in range: [-1023; 1023]
Max prefix sum: 7649 on prefix [0; 183)
CPU: 3.33333e-07+-4.71405e-07 s
CPU: 768 millions/s
GPU:     3.81667e-05+-1.95078e-06 s
GPU:     6.70742 millions/s
______________________________________________
n=512 values in range: [-1023; 1023]
Max prefix sum: 4170 on prefix [0; 52)
CPU: 8.33333e-07+-3.72678e-07 s
CPU: 614.4 millions/s
GPU:     8e-05+-3.21455e-06 s
GPU:     6.4 millions/s
______________________________________________
n=1024 values in range: [-1023; 1023]
Max prefix sum: 14708 on prefix [0; 829)
CPU: 1e-06+-0 s
CPU: 1024 millions/s
GPU:     7.38333e-05+-3.72678e-07 s
GPU:     13.8691 millions/s
______________________________________________
n=2048 values in range: [-1023; 1023]
Max prefix sum: 22303 on prefix [0; 1779)
CPU: 2.5e-06+-5e-07 s
CPU: 819.2 millions/s
GPU:     7.31667e-05+-2.67187e-06 s
GPU:     27.9909 millions/s
______________________________________________
n=4096 values in range: [-1023; 1023]
Max prefix sum: 4292 on prefix [0; 58)
CPU: 2.66667e-06+-4.71405e-07 s
CPU: 1536 millions/s
GPU:     8.11667e-05+-2.19216e-06 s
GPU:     50.4641 millions/s
______________________________________________
n=8192 values in range: [-1023; 1023]
Max prefix sum: 3297 on prefix [0; 470)
CPU: 5e-06+-5.68434e-14 s
CPU: 1638.4 millions/s
GPU:     8.48333e-05+-1.67498e-06 s
GPU:     96.5658 millions/s
______________________________________________
n=16384 values in range: [-1023; 1023]
Max prefix sum: 103982 on prefix [0; 10101)
CPU: 1.26667e-05+-1.24722e-06 s
CPU: 1293.47 millions/s
GPU:     9.43333e-05+-6.42045e-06 s
GPU:     173.682 millions/s
______________________________________________
n=32768 values in range: [-1023; 1023]
Max prefix sum: 75785 on prefix [0; 2074)
CPU: 2.1e-05+-0 s
CPU: 1560.38 millions/s
GPU:     0.000100333+-2.13437e-06 s
GPU:     326.591 millions/s
______________________________________________
n=65536 values in range: [-1023; 1023]
Max prefix sum: 93500 on prefix [0; 61715)
CPU: 3.76667e-05+-4.71405e-07 s
CPU: 1739.89 millions/s
GPU:     0.000121+-1.91485e-06 s
GPU:     541.62 millions/s
______________________________________________
n=131072 values in range: [-1023; 1023]
Max prefix sum: 310443 on prefix [0; 102163)
CPU: 8.21667e-05+-6.87184e-07 s
CPU: 1595.2 millions/s
GPU:     0.000243167+-1.5763e-05 s
GPU:     539.021 millions/s
______________________________________________
n=262144 values in range: [-1023; 1023]
Max prefix sum: 449686 on prefix [0; 211310)
CPU: 0.000246+-1.1547e-06 s
CPU: 1065.63 millions/s
GPU:     0.000345167+-2.21767e-05 s
GPU:     759.471 millions/s
______________________________________________
n=524288 values in range: [-1023; 1023]
Max prefix sum: 18511 on prefix [0; 470827)
CPU: 0.000327+-5.7735e-06 s
CPU: 1603.33 millions/s
GPU:     0.000526167+-1.52798e-05 s
GPU:     996.43 millions/s
______________________________________________
n=1048576 values in range: [-1023; 1023]
Max prefix sum: 46638 on prefix [0; 12341)
CPU: 0.000610333+-2.00472e-05 s
CPU: 1718.04 millions/s
GPU:     0.000994333+-4.40858e-05 s
GPU:     1054.55 millions/s
______________________________________________
n=2097152 values in range: [-1023; 1023]
Max prefix sum: 1199401 on prefix [0; 1691780)
CPU: 0.00159133+-2.20353e-05 s
CPU: 1317.86 millions/s
GPU:     0.00185667+-4.89138e-05 s
GPU:     1129.53 millions/s
______________________________________________
n=4194304 values in range: [-511; 511]
Max prefix sum: 43576 on prefix [0; 3543860)
CPU: 0.00291033+-0.00014632 s
CPU: 1441.18 millions/s
GPU:     0.00353167+-8.64671e-05 s
GPU:     1187.63 millions/s
______________________________________________
n=8388608 values in range: [-255; 255]
Max prefix sum: 262168 on prefix [0; 2631415)
CPU: 0.005738+-0.000155593 s
CPU: 1461.94 millions/s
GPU:     0.00697367+-0.000158019 s
GPU:     1202.9 millions/s
______________________________________________
n=16777216 values in range: [-127; 127]
Max prefix sum: 79474 on prefix [0; 976207)
CPU: 0.0121942+-0.000227033 s
CPU: 1375.84 millions/s
GPU:     0.0134567+-0.00017506 s
GPU:     1246.76 millions/s
</pre>
</p></details>


<details><summary>Вывод Travis CI</summary><p>
<pre>
$ ./aplusb
OpenCL devices:
  Device #0: CPU.            Intel(R) Xeon(R) CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 7958 Mb
Using device #0: CPU.            Intel(R) Xeon(R) CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 7958 Mb
Data generated for n=50000000!
Just example of printf usage: WARP_SIZE=1
The command "./aplusb" exited with 0.
22.37s$ ./mandelbrot
OpenCL devices:
  Device #0: CPU.            Intel(R) Xeon(R) CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 7958 Mb
Using device #0: CPU.            Intel(R) Xeon(R) CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 7958 Mb
CPU: 1.4416+-0.00208333 s
CPU: 6.93671 GFlops
    Real iterations fraction: 56.2638%
GPU: 0.479301+-0.000295959 s
GPU: 20.8637 GFlops
    Real iterations fraction: 56.2663%
GPU vs CPU average results difference: 0.982458%
The command "./mandelbrot" exited with 0.
3.73s$ ./sum
OpenCL devices:
  Device #0: CPU.            Intel(R) Xeon(R) CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 7958 Mb
Using device #0: CPU.            Intel(R) Xeon(R) CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 7958 Mb
CPU:     0.0613873+-0.000213503 s
CPU:     1629 millions/s
CPU OMP: 0.0601862+-0.000102866 s
CPU OMP: 1661.51 millions/s
GPU:     0.135718+-0.000646516 s
GPU:     736.823 millions/s
The command "./sum" exited with 0.
5.14s$ ./max_prefix_sum
OpenCL devices:
  Device #0: CPU.            Intel(R) Xeon(R) CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 7958 Mb
Using device #0: CPU.            Intel(R) Xeon(R) CPU @ 2.80GHz. Intel(R) Corporation. Total memory: 7958 Mb
______________________________________________
n=2 values in range: [-1023; 1023]
Max prefix sum: -517 on prefix [0; 2)
CPU: 3.33333e-07+-4.71405e-07 s
CPU: 6 millions/s
GPU:     9.83333e-06+-1.06719e-06 s
GPU:     26.0339 millions/s
______________________________________________
n=4 values in range: [-1023; 1023]
Max prefix sum: 1014 on prefix [0; 2)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 24 millions/s
GPU:     1.03333e-05+-4.71405e-07 s
GPU:     24.7742 millions/s
______________________________________________
n=8 values in range: [-1023; 1023]
Max prefix sum: -887 on prefix [0; 1)
CPU: 0+-0 s
CPU: inf millions/s
GPU:     1.01667e-05+-6.87184e-07 s
GPU:     25.1803 millions/s
______________________________________________
n=16 values in range: [-1023; 1023]
Max prefix sum: 457 on prefix [0; 1)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 96 millions/s
GPU:     9.66667e-06+-4.71405e-07 s
GPU:     26.4828 millions/s
______________________________________________
n=32 values in range: [-1023; 1023]
Max prefix sum: -51 on prefix [0; 1)
CPU: 1.66667e-07+-3.72678e-07 s
CPU: 192 millions/s
GPU:     1.06667e-05+-7.45356e-07 s
GPU:     24 millions/s
______________________________________________
n=64 values in range: [-1023; 1023]
Max prefix sum: 1170 on prefix [0; 17)
CPU: 5e-07+-5e-07 s
CPU: 128 millions/s
GPU:     9.83333e-06+-6.87184e-07 s
GPU:     26.0339 millions/s
______________________________________________
n=128 values in range: [-1023; 1023]
Max prefix sum: 4773 on prefix [0; 124)
CPU: 6.66667e-07+-4.71405e-07 s
CPU: 192 millions/s
GPU:     1e-05+-1e-06 s
GPU:     25.6 millions/s
______________________________________________
n=256 values in range: [-1023; 1023]
Max prefix sum: 7649 on prefix [0; 183)
CPU: 8.33333e-07+-3.72678e-07 s
CPU: 307.2 millions/s
GPU:     1.06667e-05+-7.45356e-07 s
GPU:     24 millions/s
______________________________________________
n=512 values in range: [-1023; 1023]
Max prefix sum: 4170 on prefix [0; 52)
CPU: 1.16667e-06+-3.72678e-07 s
CPU: 438.857 millions/s
GPU:     2.15e-05+-1.38444e-06 s
GPU:     23.814 millions/s
______________________________________________
n=1024 values in range: [-1023; 1023]
Max prefix sum: 14708 on prefix [0; 829)
CPU: 2.16667e-06+-3.72678e-07 s
CPU: 472.615 millions/s
GPU:     2.3e-05+-1.29099e-06 s
GPU:     44.5217 millions/s
______________________________________________
n=2048 values in range: [-1023; 1023]
Max prefix sum: 22303 on prefix [0; 1779)
CPU: 4.66667e-06+-7.45356e-07 s
CPU: 438.857 millions/s
GPU:     2.48333e-05+-1.67498e-06 s
GPU:     82.4698 millions/s
______________________________________________
n=4096 values in range: [-1023; 1023]
Max prefix sum: 4292 on prefix [0; 58)
CPU: 6.16667e-06+-1.67498e-06 s
CPU: 664.216 millions/s
GPU:     2.78333e-05+-6.87184e-07 s
GPU:     147.162 millions/s
______________________________________________
n=8192 values in range: [-1023; 1023]
Max prefix sum: 3297 on prefix [0; 470)
CPU: 9.5e-06+-3.04138e-06 s
CPU: 862.316 millions/s
GPU:     3.63333e-05+-2.13437e-06 s
GPU:     225.468 millions/s
______________________________________________
n=16384 values in range: [-1023; 1023]
Max prefix sum: 103982 on prefix [0; 10101)
CPU: 3.2e-05+-5.7735e-07 s
CPU: 512 millions/s
GPU:     5.03333e-05+-7.45356e-07 s
GPU:     325.51 millions/s
______________________________________________
n=32768 values in range: [-1023; 1023]
Max prefix sum: 75785 on prefix [0; 2074)
CPU: 6.31667e-05+-2.03443e-06 s
CPU: 518.755 millions/s
GPU:     8.55e-05+-5.85235e-06 s
GPU:     383.251 millions/s
______________________________________________
n=65536 values in range: [-1023; 1023]
Max prefix sum: 93500 on prefix [0; 61715)
CPU: 9.3e-05+-1.98326e-05 s
CPU: 704.688 millions/s
GPU:     0.0001405+-4.03113e-06 s
GPU:     466.448 millions/s
______________________________________________
n=131072 values in range: [-1023; 1023]
Max prefix sum: 310443 on prefix [0; 102163)
CPU: 0.000161833+-7.08088e-06 s
CPU: 809.92 millions/s
GPU:     0.000265333+-8.17856e-06 s
GPU:     493.99 millions/s
______________________________________________
n=262144 values in range: [-1023; 1023]
Max prefix sum: 449686 on prefix [0; 211310)
CPU: 0.000315667+-2.86744e-06 s
CPU: 830.446 millions/s
GPU:     0.0004775+-1.2829e-05 s
GPU:     548.993 millions/s
______________________________________________
n=524288 values in range: [-1023; 1023]
Max prefix sum: 18511 on prefix [0; 470827)
CPU: 0.000502667+-3.36039e-05 s
CPU: 1043.01 millions/s
GPU:     0.000910833+-1.2615e-05 s
GPU:     575.614 millions/s
______________________________________________
n=1048576 values in range: [-1023; 1023]
Max prefix sum: 46638 on prefix [0; 12341)
CPU: 0.00102983+-2.35755e-05 s
CPU: 1018.2 millions/s
GPU:     0.001774+-1.66433e-05 s
GPU:     591.08 millions/s
______________________________________________
n=2097152 values in range: [-1023; 1023]
Max prefix sum: 1199401 on prefix [0; 1691780)
CPU: 0.00245717+-3.99559e-05 s
CPU: 853.484 millions/s
GPU:     0.0035325+-2.1274e-05 s
GPU:     593.674 millions/s
______________________________________________
n=4194304 values in range: [-511; 511]
Max prefix sum: 43576 on prefix [0; 3543860)
CPU: 0.00419283+-7.49187e-05 s
CPU: 1000.35 millions/s
GPU:     0.00693217+-5.5496e-05 s
GPU:     605.05 millions/s
______________________________________________
n=8388608 values in range: [-255; 255]
Max prefix sum: 262168 on prefix [0; 2631415)
CPU: 0.00855817+-0.000103549 s
CPU: 980.188 millions/s
GPU:     0.0137747+-8.1375e-05 s
GPU:     608.988 millions/s
______________________________________________
n=16777216 values in range: [-127; 127]
Max prefix sum: 79474 on prefix [0; 976207)
CPU: 0.0162843+-7.68021e-05 s
CPU: 1030.27 millions/s
GPU:     0.027446+-7.93641e-05 s
GPU:     611.281 millions/s
The command "./max_prefix_sum" exited with 0.
</pre>
</p></details>